### PR TITLE
Added more debug information for if a check matches the node range in nhc.conf

### DIFF
--- a/scripts/common.nhc
+++ b/scripts/common.nhc
@@ -357,6 +357,10 @@ function nhc_load_conf() {
         # Skip empty targets or checks.
         test "$TARGET" = "" -o "$CHECK" = "" && continue
 
+        # Print Debug Information if a check does not match
+        mcheck "$HOSTNAME" "$TARGET" || dbg "Host match check: '${HOSTNAME}' does not match '${TARGET}' for check: $CHECK"
+        mcheck "$HOSTNAME" "$TARGET" && dbg "Host match check: '${HOSTNAME}' does match '${TARGET}' for check: $CHECK"
+
         # Check to see if the current host matches the check we just read.
         # If we didn't match, skip to the next line.
         mcheck "$HOSTNAME" "$TARGET" || continue


### PR DESCRIPTION
This allows for easier debugging if a check does or does not match a specific node range.  The need for this came when a typo in a node range caused some checks to not run on a specific range of nodes, this went unnoticed and was difficult to troubleshoot without these additional debug messages.