### PR TITLE
fixed misleading timeout message if nhc times out after all checks were completed

### DIFF
--- a/nhc
+++ b/nhc
@@ -617,6 +617,7 @@ function nhcmain_run_checks() {
         kill_watchdog
         exit $FAIL_CNT
     fi
+    CHECK="post check portions of nhc, after all checks completed successfully"
 }
 
 function nhcmain_mark_online() {


### PR DESCRIPTION
nhc was timing out because of the pbsnodes command timing out in "/usr/libexec/nhc/node-mark-online", the nhc message was originally misleading because it marked it offline as timing out during the last check and the $CHECK variable was not reset after all checks were completed successfully.  This change simply sets the $CHECK variable to a better description after the last check completes successfully.

Instead of the bellow message if nhc times out during "node-mark-online":
[root@n0020 ~]# nhc
ERROR:  nhc:  Health check failed:  Script timed out while executing "free ram check".

It now shows:
[root@n0020 ~]# nhc
ERROR:  nhc:  Health check failed:  Script timed out while executing "post check portions of nhc, after all checks completed successfully".