### PR TITLE
This fixes #15 by using squeue instead of stat to obtain the list of authorized users

### DIFF
--- a/scripts/lbnl_job.nhc
+++ b/scripts/lbnl_job.nhc
@@ -9,7 +9,7 @@ NHC_AUTH_USERS="${NHC_AUTH_USERS:-root nobody}"
 
 # Find all users with jobs currently running on the node.
 function nhc_job_find_users() {
-    local IFS JOBFILE JOBUSER STAT_OUT LINE PBS_XML
+    local IFS JOBFILE JOBUSER SQUEUE_OUT LINE PBS_XML
     local -a JOBLIST USERLIST
 
     dbg "Searching for job files"
@@ -54,9 +54,9 @@ function nhc_job_find_users() {
     elif [[ "$NHC_RM" == "slurm" ]]; then
         SLURM_SERVER_HOME="${SLURM_SERVER_HOME:-/var/spool/slurmd}"
         JOBFILE_PATH="${JOBFILE_PATH:-$SLURM_SERVER_HOME}"
-        STAT_OUT=$(${STAT_CMD:-/usr/bin/stat} ${STAT_FMT_ARGS:--c} %U $JOBFILE_PATH/job*/slurm_script)
+	SQUEUE_OUT=$(${SQUEUE_CMD:-/usr/bin/squeue} ${SQUEUE_NODE:--w $(hostname -s)} ${SQUEUE_FMT_ARGS:---noheader -o  %u})
         IFS=$'\n'
-        USERLIST=( $STAT_OUT )
+        USERLIST=( $SQUEUE_OUT )
         IFS=$' \t\n'
         dbg "Found ${#USERLIST[*]} job files in $JOBFILE_PATH"
         for JOBUSER in "${USERLIST[@]}" ; do


### PR DESCRIPTION
This fixes #15  by using squeue instead of stat to obtain the list of authorized users.
This has been tested with NHC 1.4.2 on clusters running SLURM 14.11 and 15.08.