### PR TITLE
Allow SLURM nodes in reservation to be marked offline

### DIFF
--- a/helpers/node-mark-offline
+++ b/helpers/node-mark-offline
@@ -63,7 +63,7 @@ elif [[ "$NHC_RM" == "slurm" ]]; then
     OLD_NOTE_LEADER="${LINE[1]}"
     OLD_NOTE="${LINE[*]:2}"
     case "$STATUS" in
-        alloc*|comp*|drain*|drng*|fail*|idle*|maint*|mix*|resume*|undrain*)
+        alloc*|comp*|drain*|drng*|fail*|idle*|maint*|mix*|resume*|resv*|undrain*)
             case "$STATUS" in
                 drain*|drng*|fail*|maint*)
                     # If the node is already offline, and there is no old note, and

--- a/helpers/node-mark-online
+++ b/helpers/node-mark-online
@@ -74,7 +74,7 @@ elif [[ "$NHC_RM" == "slurm" ]]; then
             echo "$0:  Marking $HOSTNAME online and clearing note ($OLD_NOTE_LEADER $OLD_NOTE)"
             exec $SLURM_SCONTROL $SLURM_SC_ONLINE_ARGS NodeName=$HOSTNAME
             ;;
-        alloc*|comp*|idle*|mix*|resume*|undrain*)
+        alloc*|comp*|idle*|mix*|resume*|resv*|undrain*)
             # Node is already online.
             echo "$0:  Node $HOSTNAME is already online."
             ;;


### PR DESCRIPTION
SLURM added node state 'reserved' in v14.03: SchedMD/slurm@5e54ccd7096f4c37d39563e7e7857c9a1083bc45

Example output for an idle node in a reservation:
```
$ sinfo -o '%t %E' -hn c0001
resv none
```

This patch considers 'resv' nodes as equivalent to 'idle'.