### PR TITLE
Add EDAC hardware check (ECC memory errors)

### DIFF
--- a/scripts/lbnl_hw.nhc
+++ b/scripts/lbnl_hw.nhc
@@ -21,6 +21,10 @@ MCELOG="${MCELOG:-mcelog}"
 MCELOG_ARGS="${MCELOG_ARGS:---client}"
 MCELOG_MAX_CORRECTED_RATE="${MCELOG_MAX_CORRECTED_RATE:-9}"
 MCELOG_MAX_UNCORRECTED_RATE="${MCELOG_MAX_UNCORRECTED_RATE:-0}"
+EDAC="${EDAC:-edac-util}"
+EDAC_ARGS="${EDAC_ARGS:-}"
+EDAC_MAX_CORRECTED="${EDAC_MAX_CORRECTED:-9}"
+EDAC_MAX_UNCORRECTED="${EDAC_MAX_UNCORRECTED:-0}"
 
 # Read hardware information from /proc and /sys files.
 function nhc_hw_gather_data() {
@@ -460,7 +464,7 @@ function check_hw_mcelog() {
             die 1 "$MSG"
             return 1
         fi
-        
+
         # If none of the above thresholds was met, return success.
         return 0
     else
@@ -469,4 +473,68 @@ function check_hw_mcelog() {
         die 1 "$FUNCNAME:  MCEs detected in log."
         return 1
     fi
+}
+
+# Check for EDAC errors
+function check_hw_edac() {
+    local HW_EDAC_ERRS MSG=""
+    local -a ERROR_LINES ERROR_LINE
+    local i
+
+    HW_EDAC_ERRS=$($EDAC $EDAC_ARGS 2>&1)
+    if [[ -z "$HW_EDAC_ERRS" ]]; then
+        return 0
+    elif mcheck_glob "$HW_EDAC_ERRS" "*No memory controller data found*" ; then
+        log "$FUNCNAME:  No memory controller data found on $HOSTNAME"
+        syslog "$FUNCNAME:  No memory controller data found on $HOSTNAME"
+        return 0
+    elif [[ -n "$EDAC_MAX_CORRECTED" && -n "$EDAC_MAX_UNCORRECTED" ]]; then
+        IFS=$'\n'
+        ERROR_LINES=( $HW_EDAC_ERRS )
+        IFS=$' \t\n'
+
+        dbg "$FUNCNAME:  Checking for hardware-related EDAC errors (with thresholds of $EDAC_MAX_CORRECTED corrected or $EDAC_MAX_UNCORRECTED uncorrected errors)"
+
+        # Determine if hardware errors have been reported.
+        # Corrected errors (CE) are OK in small quantities.
+        # The expected edac-util output format for each MC with errors will be:
+        #
+        # mc1: csrow3: CPU_SrcID#1_Channel#3_DIMM#0: 19 Corrected Errors
+        #
+        for ((i=0; i<${#ERROR_LINES[*]}; i++)); do
+            if [[ "${ERROR_LINES[$i]}" =~ "Corrected Errors" ]] ; then
+                ERROR_LINE=( ${ERROR_LINES[$i]} )
+                NUM_CE=${ERROR_LINE[$((${#ERROR_LINE[@]}-3))]}
+                dbg "$FUNCNAME:  This DIMM detected ${NUM_CE} corrected errors"
+
+                if [[ ${NUM_CE} -gt $EDAC_MAX_CORRECTED ]]; then
+                    MSG="$FUNCNAME:  ECC errors detected - ${NUM_CE} corrected memory errors detected (limit of $EDAC_MAX_CORRECTED)."
+                    break
+                fi
+            elif [[ "${ERROR_LINES[$i]}" == "Uncorrected Errors" ]] ; then
+                ERROR_LINE=( ${ERROR_LINES[$i]} )
+                NUM_UE=${ERROR_LINE[$((${#ERROR_LINE[@]}-3))]}
+                dbg "$FUNCNAME:  This DIMM detected ${NUM_UE} UNcorrected errors"
+
+                if [[ ${NUM_UE} -gt $EDAC_MAX_UNCORRECTED ]]; then
+                    MSG="$FUNCNAME:  ECC errors detected - ${NUM_UE} UNcorrected memory errors detected (limit of $EDAC_MAX_UNCORRECTED)."
+                    break
+                fi
+            fi
+        done
+        if [[ -n "$MSG" ]]; then
+            log "$MSG"
+            die 1 "$MSG"
+            return 1
+        fi
+
+        # If none of the above thresholds was met, return success.
+        return 0
+    else
+        dbg "$FUNCNAME:  edac-util output was not empty; thresholds have not been set, so we must assume the detected errors are fatal"
+        log "$FUNCNAME:  ECC errors detected:  $HW_EDAC_ERRS"
+        die 1 "$FUNCNAME:  ECC errors detected"
+        return 1
+    fi
+
 }


### PR DESCRIPTION
This patch will add a `check_hw_edac` check to verify correctable and uncorrectable ECC errors in memory, as reported by [`edac-utils`](https://github.com/grondo/edac-utils)

EDAC is an alternative to MCE checks, with support for older hardware (cf. http://www.mcelog.org/faq.html#13) and could be used on platforms where `mcelog` is not available.

```
# edac-util
mc1: csrow1: CPU_SrcID#1_Channel#1_DIMM#0: 31 Corrected Errors

# nhc -e check_hw_edac MARK_OFFLINE=0
check_hw_edac:  ECC errors detected - 31 corrected memory errors detected (limit of 9).
ERROR:  nhc:  Health check failed:  check_hw_edac:  ECC errors detected - 31 corrected memory errors detected (limit of 9).
ERROR:  nhc:  Health check failed:  check_hw_edac:  ECC errors detected - 31 corrected memory errors detected (limit of 9).
```

It is very closely modelled after the `check_hw_mcelog` function, with similar thresholds definitions.