### PR TITLE
Detection for pbspro RM, added PBSpro offline and online helpers

### DIFF
--- a/helpers/node-mark-offline
+++ b/helpers/node-mark-offline
@@ -52,6 +52,46 @@ if [[ "$NHC_RM" == "pbs" ]]; then
     echo "$0:  Marking $STATUS $HOSTNAME offline:  $LEADER $NOTE"
     exec $PBSNODES $PBSNODES_OFFLINE_ARGS "$LEADER $NOTE" $HOSTNAME
 
+
+### PBSPRO
+elif [[ "$NHC_RM" == "pbspro" ]]; then
+    PBSNODES="${PBSNODES:-pbsnodes}"
+    PBSNODES_LIST_ARGS="${PBSNODES_LIST_ARGS:--l}"
+    PBSNODES_OFFLINE_ARGS="${PBSNODES_OFFLINE_ARGS:--o -C}"
+
+    IFS=$'\n'
+    LINES=$($PBSNODES $PBSNODES_LIST_ARGS)
+    for LINE_RAW in $LINES; do
+    IFS=' '
+    LINE=($LINE_RAW)
+    if [[ "${LINE[0]}" == "$HOSTNAME" ]]; then
+    STATUS="${LINE[1]}"
+    OLD_NOTE_LEADER="${LINE[2]}"
+    OLD_NOTE="${LINE[*]:3}"
+    case "$STATUS" in
+        *down*|*offline*|*unknown*)
+            if [[ "${STATUS/offline}" != "${STATUS}" ]]; then
+                # If the node is already offline, and there is no old note, and
+                # we've not been told to ignore that, do not touch the node.
+                if [[ -z "$OLD_NOTE_LEADER" && "$IGNORE_EMPTY_NOTE" != "1" ]]; then
+                    echo "$0:  Not offlining $HOSTNAME:  Already offline with no note set."
+                    exit 0
+                fi
+            fi
+            # If there's an old note that wasn't set by NHC, preserve it.
+            if [[ -n "$OLD_NOTE_LEADER" && "$OLD_NOTE_LEADER" != "$LEADER" ]]; then
+                LEADER="$OLD_NOTE_LEADER"
+                NOTE="$OLD_NOTE"
+            fi
+            ;;
+    esac
+    fi
+    done
+
+    echo "$0:  Marking $STATUS $HOSTNAME offline:  $LEADER $NOTE"
+    exec $PBSNODES $PBSNODES_OFFLINE_ARGS "$LEADER $NOTE" $HOSTNAME
+
+
 ### SLURM
 elif [[ "$NHC_RM" == "slurm" ]]; then
     SLURM_SINFO="${SLURM_SINFO:-sinfo}"

--- a/helpers/node-mark-online
+++ b/helpers/node-mark-online
@@ -47,7 +47,7 @@ if [[ "$NHC_RM" == "pbs" ]]; then
     echo "$0:  Skipping $STATUS node $HOSTNAME ($OLD_NOTE_LEADER $OLD_NOTE)"
 
 
-### PBSpro
+### PBSPRO
 elif [[ "$NHC_RM" == "pbspro" ]]; then
     PBSNODES="${PBSNODES:-pbsnodes}"
     PBSNODES_LIST_ARGS="${PBSNODES_LIST_ARGS:--l}"
@@ -58,7 +58,6 @@ elif [[ "$NHC_RM" == "pbspro" ]]; then
     for LINE_RAW in $LINES; do
     IFS=' '
     LINE=( $LINE_RAW )
-    echo "${LINE[0]}" >> /tmp/testnhc
     if [[ "${LINE[0]}" == "$HOSTNAME" ]]; then
     STATUS="${LINE[1]}"
     OLD_NOTE_LEADER="${LINE[2]}"

--- a/helpers/node-mark-online
+++ b/helpers/node-mark-online
@@ -75,8 +75,11 @@ elif [[ "$NHC_RM" == "pbspro" ]]; then
                 exit 0
             fi
             echo "$0:  Marking $HOSTNAME online and clearing note ($OLD_NOTE_LEADER $OLD_NOTE)"
-            exec $PBSNODES $PBSNODES_ONLINE_ARGS $HOSTNAME
-            exec $PBSNODES -C '' $HOSTNAME # Note Clear, With PBSpro you cannot clear in the same command
+            # PBSpro cannot clear and online in the same command
+            if $PBSNODES -C '' $HOSTNAME ; then
+                # If the note clear finished successfully, online node
+                exec $PBSNODES $PBSNODES_ONLINE_ARGS $HOSTNAME
+            fi
             ;;
     esac
     fi

--- a/helpers/node-mark-online
+++ b/helpers/node-mark-online
@@ -47,6 +47,44 @@ if [[ "$NHC_RM" == "pbs" ]]; then
     echo "$0:  Skipping $STATUS node $HOSTNAME ($OLD_NOTE_LEADER $OLD_NOTE)"
 
 
+### PBSpro
+elif [[ "$NHC_RM" == "pbspro" ]]; then
+    PBSNODES="${PBSNODES:-pbsnodes}"
+    PBSNODES_LIST_ARGS="${PBSNODES_LIST_ARGS:--l}"
+    PBSNODES_ONLINE_ARGS="${PBSNODES_ONLINE_ARGS:--c}"
+
+    IFS=$'\n'
+    LINES=$($PBSNODES $PBSNODES_LIST_ARGS)
+    for LINE_RAW in $LINES; do
+    IFS=' '
+    LINE=( $LINE_RAW )
+    echo "${LINE[0]}" >> /tmp/testnhc
+    if [[ "${LINE[0]}" == "$HOSTNAME" ]]; then
+    STATUS="${LINE[1]}"
+    OLD_NOTE_LEADER="${LINE[2]}"
+    OLD_NOTE="${LINE[*]:3}"
+    case "$STATUS" in
+        *offline*)
+            # If there is no old note, and we've not been told to ignore that, do not online the node.
+            if [[ -z "$OLD_NOTE_LEADER" && "$IGNORE_EMPTY_NOTE" != "1" ]]; then
+                echo "$0:  Not onlining $HOSTNAME:  No note set."
+                exit 0
+            fi
+            # If there IS an old note, but it wasn't set by NHC, do not online the node.
+            if [[ -n "$OLD_NOTE_LEADER" && "$OLD_NOTE_LEADER" != "$LEADER" ]]; then
+                echo "$0:  Not onlining $HOSTNAME:  Offline for non-NHC reason ($OLD_NOTE_LEADER $OLD_NOTE)"
+                exit 0
+            fi
+            echo "$0:  Marking $HOSTNAME online and clearing note ($OLD_NOTE_LEADER $OLD_NOTE)"
+            exec $PBSNODES $PBSNODES_ONLINE_ARGS $HOSTNAME
+            exec $PBSNODES -C '' $HOSTNAME # Note Clear, With PBSpro you cannot clear in the same command
+            ;;
+    esac
+    fi
+    done
+    echo "$0:  Skipping $STATUS node $HOSTNAME ($OLD_NOTE_LEADER $OLD_NOTE)"
+
+
 ### SLURM
 elif [[ "$NHC_RM" == "slurm" ]]; then
     SLURM_SINFO="${SLURM_SINFO:-sinfo}"

--- a/nhc
+++ b/nhc
@@ -433,10 +433,24 @@ function nhcmain_find_rm() {
         NHC_RM="sge"
     fi
 
+    if [[ -d /var/spool/pbs ]]; then
+        NHC_RM="pbspro"
+        return 0
+    fi
+
     # Search PATH for commands
     if type -a -p -f -P pbsnodes >&/dev/null ; then
-        NHC_RM="pbs"
-        return 0
+        # PBSpro prints version to stdout, Torque prints version to stderr
+        VERSION_LINE=( $($(type -a -p -f -P pbsnodes) --version 2>&1) )
+        if [[ "pbs_version" == ${VERSION_LINE[0]} ]]; then
+            NHC_RM="pbspro"
+            return 0
+        else
+            # Assume Torque if its not PBSpro
+            # [[ "Version:" == ${VERSION_LINE[0]} ]] is True
+            NHC_RM="pbs"
+            return 0
+        fi
     elif type -a -p -f -P scontrol >&/dev/null ; then
         NHC_RM="slurm"
         return 0

--- a/nhc
+++ b/nhc
@@ -440,14 +440,11 @@ function nhcmain_find_rm() {
 
     # Search PATH for commands
     if type -a -p -f -P pbsnodes >&/dev/null ; then
-        # PBSpro prints version to stdout, Torque prints version to stderr
-        VERSION_LINE=( $($(type -a -p -f -P pbsnodes) --version 2>&1) )
-        if [[ "pbs_version" == ${VERSION_LINE[0]} ]]; then
+        if  type -a -p -f -P pbs_password >&/dev/null ; then
+            # PBSpro has the command pbs_password, Torque does not
             NHC_RM="pbspro"
             return 0
         else
-            # Assume Torque if its not PBSpro
-            # [[ "Version:" == ${VERSION_LINE[0]} ]] is True
             NHC_RM="pbs"
             return 0
         fi


### PR DESCRIPTION
Building a small test cluster using PBSpro and I wasn't able to get NHC working out-of-the-box with PBSpro due to the differences in the pbsnodes command.  The differences required more than changing the arguments to pbsnodes, it required parsing differences of the command output and multiple commands to online the node and clear the note.

Below are the differences between Torque pbsnodes and PBSpro pbsnodes that are applicable to NHC.

1. pbsnodes -nl $nodename does not work in PBSpro.  You have to do pbsnodes -l, then parse the line your intersted in.

2. pbsnodes -c -N '' $nodename does not work in PBSpro.  You have to do pbsnodes -c nodename && pbsnodes -C '' $nodename; I was not able to find a way to do it with a single command.

-David