### PR TITLE
Speed up nhc_hw_gather_data function for KNL

### DIFF
--- a/scripts/lbnl_hw.nhc
+++ b/scripts/lbnl_hw.nhc
@@ -47,7 +47,7 @@ function nhc_hw_gather_data() {
                 MHZ="${FIELD[3]}"
                 MHZ="${MHZ/%.*}"
             fi
-        done < /proc/cpuinfo
+        done < <(/usr/bin/grep "processor\|physical id\|siblings\|cpu cores\|cpu MHz" /proc/cpuinfo)
     fi
     if [[ $PROCESSOR -ge 0 && $HW_SOCKETS -eq 0 ]]; then
         HW_SOCKETS=$((PROCESSOR+1))


### PR DESCRIPTION
Reduces number of access to /proc/cpuinfo in the nhc_hw_gather_data function. For processors like Intel Phi KNL with 256+ threads, the function was taking over 40 seconds to return. Running on a normal file, the function should only take about 4 seconds. Pre-filtering with grep shortens the function runtime further to 1.5s on a 1.4GHz (64 core, 256 thread) KNL.