### PR TITLE
Make nhc debian aware

### DIFF
--- a/nhc
+++ b/nhc
@@ -181,8 +181,14 @@ function nhcmain_init_env() {
 
     # Static variables
     PATH="/sbin:/usr/sbin:/bin:/usr/bin"
-    SYSCONFIGDIR="/etc/sysconfig"
-    LIBEXECDIR="/usr/libexec"
+    if [ -f /etc/debian_version ]
+    then
+        SYSCONFIGDIR="/etc/default"
+        LIBEXECDIR="/usr/lib"
+    else
+        SYSCONFIGDIR="/etc/sysconfig"
+        LIBEXECDIR="/usr/libexec"
+    fi
     if [[ -r /proc/sys/kernel/hostname ]]; then
         read HOSTNAME < /proc/sys/kernel/hostname
     elif [[ -z "$HOSTNAME" ]]; then

--- a/nhc-genconf
+++ b/nhc-genconf
@@ -56,8 +56,14 @@ function dbg() {
 function nhcgc_init_env() {
     umask 0077
     PATH="/sbin:/usr/sbin:/bin:/usr/bin"
-    SYSCONFIGDIR="/etc/sysconfig"
-    LIBEXECDIR="/usr/libexec"
+    if [ -f /etc/debian_version ]
+    then
+        SYSCONFIGDIR="/etc/default"
+        LIBEXECDIR="/usr/lib"
+    else
+        SYSCONFIGDIR="/etc/sysconfig"
+        LIBEXECDIR="/usr/libexec"
+    fi
     if [[ -r /proc/sys/kernel/hostname ]]; then
         read HOSTNAME < /proc/sys/kernel/hostname
     else

--- a/nhc-wrapper
+++ b/nhc-wrapper
@@ -84,8 +84,14 @@ function nhc_parse_timespec() {
 function nhcwrap_init_env() {
     umask 0077
     PATH="/sbin:/usr/sbin:/bin:/usr/bin"
-    SYSCONFIGDIR="/etc/sysconfig"
-    LIBEXECDIR="/usr/libexec"
+    if [ -f /etc/debian_version ]
+    then
+        SYSCONFIGDIR="/etc/default"
+        LIBEXECDIR="/usr/lib"
+    else
+        SYSCONFIGDIR="/etc/sysconfig"
+        LIBEXECDIR="/usr/libexec"
+    fi
     if [[ -r /proc/sys/kernel/hostname ]]; then
         read HOSTNAME < /proc/sys/kernel/hostname
     else


### PR DESCRIPTION
based on:
 * https://github.com/edf-hpc/warewulf-nhc/blob/master/debian/patches/0001-Detect-debian-path-for-SYSCONFDIR-and-LIBEXECDIR.patch
 * https://github.com/mej/nhc/issues/38