### PR TITLE
Add GPFS health check

### DIFF
--- a/scripts/osc_gpfs.nhc
+++ b/scripts/osc_gpfs.nhc
@@ -1,0 +1,121 @@
+# OSC NHC - GPFS checks
+#
+# Trey Dockendorf <tdockendorf@osc.edu>
+# 1 November 2018
+#
+
+GPFS_COMPONENT=()
+GPFS_ENTITY=()
+GPFS_STATUS=()
+export GPFS_COMPONENT GPFS_ENTITY GPFS_STATUS
+
+function nhc_gpfs_health_gather_data() {
+    local LINE_CNT
+    local -a FIELD
+
+    GPFS_COMPONENT=() GPFS_ENTITY=() GPFS_STATUS=()
+
+    ((LINE_CNT=0))
+    while IFS=: read -a FIELD; do
+        if [[ "${FIELD[2]}" == "HEADER" ]]; then
+            continue
+        fi
+        if [[ "${FIELD[1]}" == "Event" ]]; then
+            continue
+        fi
+        if [[ "${FIELD[9]}" != "NODE" ]]; then
+            continue
+        fi
+        GPFS_COMPONENT[$LINE_CNT]="${FIELD[7]}"
+        GPFS_ENTITY[$LINE_CNT]="${FIELD[8]}"
+        GPFS_STATUS[$LINE_CNT]="${FIELD[10]}"
+        dbg "Got GPFS health ${GPFS_COMPONENT[$LINE_CNT]} ${GPFS_ENTITY[$LINE_CNT]} ${GPFS_STATUS[$LINE_CNT]}"
+        ((LINE_CNT++))
+    done < <(/usr/lpp/mmfs/bin/mmhealth node show -Y)
+
+    export GPFS_COMPONENT GPFS_ENTITY GPFS_STATUS
+}
+
+# Checks GPFS health for a given component
+#   check_gpfs_health [-0] [-a] [-l] [-s] [-e <action>] <component>
+function check_gpfs_health() {
+    local NONFATAL=0 ALL=0 LOG=0 SYSLOG=0 ACTION=""
+    local THIS_COMPONENT THIS_ENTITY THIS_STATUS MSG i
+
+    if [[ ${#GPFS_COMPONENT[*]} -eq 0 ]]; then
+        nhc_gpfs_health_gather_data
+    fi
+
+    OPTIND=1
+    while getopts ":0alse:" OPTION ; do
+        case "$OPTION" in
+            0) NONFATAL=1 ;;
+            a) ALL=1 ;;
+            l) LOG=1 ;;
+            s) SYSLOG=1 ;;
+            e) ACTION="$OPTARG" ;;
+            :) die 1 "$CHECK:  Option -$OPTARG requires an argument." ; return 1 ;;
+            \?) die 1 "$CHECK:  Invalid option:  -$OPTARG" ; return 1 ;;
+        esac
+    done
+    shift $((OPTIND-1))
+    COMPONENT="$1"
+    if [[ -z "$COMPONENT" ]]; then
+        die 1 "$CHECK: Syntax error: Must provide component to check."
+    fi
+    dbg "Looking for GPFS health component \"$COMPONENT\""
+    for ((i=0; i < ${#GPFS_COMPONENT[*]}; i++)); do
+        THIS_COMPONENT="${GPFS_COMPONENT[$i]}"
+        THIS_ENTITY="${GPFS_ENTITY[$i]}"
+        THIS_STATUS="${GPFS_STATUS[$i]}"
+        dbg "CHECKING \"$THIS_COMPONENT\" vs. \"$GPFS_COMPONENT\""
+        if ! mcheck "$THIS_COMPONENT" "$COMPONENT"; then
+            continue
+        fi
+        dbg "Matching GPFS health found: $THIS_COMPONENT: entity=$THIS_ENTITY status=$THIS_STATUS"
+        if [[ "$THIS_STATUS" == "HEALTHY" ]]; then
+            continue
+        else
+            MSG="$CHECK: GPFS health for \"$THIS_COMPONENT\" is $THIS_STATUS"
+        fi
+        # We have a winner.  Or loser, as the case may be.
+        if [[ "$LOG" == "1" ]]; then
+            log $MSG
+        fi
+        if [[ "$SYSLOG" == "1" ]]; then
+            syslog $MSG
+        fi
+        if [[ "$ACTION" != "" ]]; then
+            ${SHELL:-/bin/bash} -c "$ACTION" &
+        fi
+        if [[ $ALL -ge 1 ]]; then
+            if [[ -n "$MSG" ]]; then
+                log "$MSG ($ALL)"
+            fi
+            ((ALL++))
+            continue
+        elif [[ $NONFATAL == 1 ]]; then
+            if [[ -n "$MSG" ]]; then
+                log "$MSG (non-fatal)"
+            fi
+            return 0
+        fi
+        die 1 "$MSG"
+        return 1
+    done
+    # -a (all) does not necessarily imply -0 (non-fatal).  A value of 1 for $ALL
+    # means -a was passed in but no errors were found.  2 or above is an error.
+    if [[ $ALL -gt 1 ]]; then
+        # We had at least 1 flagged process.  Fail unless we're also non-fatal.
+        if [[ $NONFATAL == 1 ]]; then
+            if [[ -n "$MSG" ]]; then
+                log "$MSG (non-fatal)"
+            fi
+            return 0
+        fi
+        ((ALL--))
+        die $ALL "$MSG (last of $ALL)"
+        return $ALL
+    fi
+    return 0
+}


### PR DESCRIPTION
I have only deployed this onto one system and one where I knew there were GPFS network issues with nodes not using RDMA that was configured:

```
[root@p0001 ~]# nhc
ERROR:  nhc:  Health check failed:  check_gpfs_health NETWORK: GPFS health for "NETWORK" is FAILED
```

Configured check:

```
* || check_gpfs_health NETWORK
```

One thing I am not sure on for behavior is what to do if the configured component isn't found in output, right now if you do `check_gpfs_health FOO`, there is no warning of failure.