### PR TITLE
Fix unsafe string array conversion for passwd file parsing

### DIFF
--- a/scripts/common.nhc
+++ b/scripts/common.nhc
@@ -406,7 +406,7 @@ function nhc_common_parse_passwd_entry() {
     local THIS_UID
     local -a LINE
 
-    read -a LINE <<< "$PASSWD_ENTRY
+    read -a LINE <<< "$PASSWD_ENTRY"
     THIS_UID=${LINE[2]}
     PWDATA_UIDS[${#PWDATA_UIDS[*]}]=$THIS_UID
     PWUID_USER[$THIS_UID]="${LINE[0]}"

--- a/scripts/common.nhc
+++ b/scripts/common.nhc
@@ -406,7 +406,7 @@ function nhc_common_parse_passwd_entry() {
     local THIS_UID
     local -a LINE
 
-    LINE=( $PASSWD_ENTRY )
+    read -a LINE <<< "$PASSWD_ENTRY
     THIS_UID=${LINE[2]}
     PWDATA_UIDS[${#PWDATA_UIDS[*]}]=$THIS_UID
     PWUID_USER[$THIS_UID]="${LINE[0]}"


### PR DESCRIPTION
If a passwd file contains a line like below with a '*' in the second field you'll get an error like below if the CWD's first listed file has a '.' in it. In our case for slurm was /var/spool/slurm.

User:*:547:15815:User:/home/User:/bin/bash

common.nhc: line 381: cred_state.old: syntax error: invalid arithmetic operator (error token is ".old")
NHC watchdog timer 26036 (60 secs) has expired.  Signaling NHC:  kill -s ALRM -- -26035
nhc: line 491: kill: (-26035) - No such process

The array conversion bash is parsing *  as list files in directory. * is a valid field in passwd just not used often.