### PR TITLE
nhc: Refactor watchdog timer code for reuse

### DIFF
--- a/nhc
+++ b/nhc
@@ -241,7 +241,7 @@ function nhcmain_init_env() {
 
     # Static variables
     PATH="/sbin:/usr/sbin:/bin:/usr/bin"
-    PS4='>[{L${SHLVL}/S${BASH_SUBSHELL}/D$((${#FUNCNAME[*]}==0?1:${#FUNCNAME[*]}))/R$?}@${BASH_SOURCE##*/}:${LINENO}:${FUNCNAME[0]}()]> '
+    PS4='>[<${BASHPID}.$((BASHPID==$$?0:$$)).${PPID}>{L${SHLVL}/S${BASH_SUBSHELL}/D$((${#FUNCNAME[*]}==0?1:${#FUNCNAME[*]}))/R$?}@${BASH_SOURCE##*/}:${LINENO}:${FUNCNAME[0]}()]> '
     if [[ -f "/etc/debian_version" ]]; then
         SYSCONFIGDIR="/etc/default"
         LIBEXECDIR="/usr/lib"

--- a/nhc
+++ b/nhc
@@ -170,19 +170,48 @@ function syslog_flush() {
     LOGGER_TEXT=""
 }
 
+    # Sleep some number of seconds, 100ms at a time, aborting if the PID dies
+function sleep_wait() {
+    local -i TLIM=$((${1:-1} * 10)) WPID="${2:-$NHC_PID}" KSIG="${3:-0}"
+    local -i i=0
+
+    while kill -s "$KSIG" -- ${WPID#-} 2>/dev/null && (( i < TLIM )); do
+        if ! sleep 0.1; then
+            # It's unlikely we'll encounter a `sleep` that can't take
+            # non-integer time values, but just in case, handle it.
+            sleep $1    # Best effort - sleep the original amount
+            return $?
+        fi
+        (( i++ ))
+    done
+    # Return 1 (failure) if the PID is still there after full sleep time
+    return $(( (i == TLIM) ? (1) : (0) ))
+}
+
 function kill_watchdog() {
+    local KPID=${1:-${NHC_WATCHDOG:-0}}
     local i
 
-    dbg "$FUNCNAME:  Watchdog PID is $WATCHDOG_PID."
-    if [[ $WATCHDOG_PID -ne 0 ]]; then
+    if [[ $KPID -ne 0 ]]; then
+        dbg "$FUNCNAME($*):  Terminating watchdog timer $KPID; main NHC watchdog PID is $NHC_WATCHDOG."
         for i in 1 2 3 4 ; do
-            dbg "Killing watchdog timer $WATCHDOG_PID -- Attempt #$i"
-            kill -s INT -- -$WATCHDOG_PID $WATCHDOG_PID 2>/dev/null || return 0
-            sleep 0.01 || sleep 1
+            dbg "Killing watchdog timer $KPID -- Attempt #$i"
+            kill -s INT -- -$KPID $KPID 2>/dev/null || return 0
+            sleep_wait 1 "$KPID"
         done
-        kill -s KILL -- -$WATCHDOG_PID $WATCHDOG_PID 2>/dev/null
+        kill -s KILL -- -$KPID $KPID 2>/dev/null
+    else
+        dbg "$FUNCNAME($*):  Invalid watchdog PID $KPID; main NHC watchdog PID is $NHC_WATCHDOG."
+        return 2
     fi
-    return 0
+
+    if sleep_wait 2 $KPID; then
+        dbg "$FUNCNAME($*):  Successfully terminated watchdog timer $KPID."
+        return 0
+    else
+        dbg "$FUNCNAME($*):  Unable to terminate defunct watchdog timer $KPID (survived SIGKILL)."
+        return 1
+    fi
 }
 
 function toggle_bash_tracing() {
@@ -246,13 +275,13 @@ function nhcmain_init_env() {
         unset BASHPID
     fi
     NHC_START_TS=0
-    WATCHDOG_PID=0
+    NHC_WATCHDOG=0
     FAIL_CNT=0
     FORCE_SETSID=1
     NHC_FD_OUT=1
     NHC_FD_ERR=2
     export PATH PS4 SYSCONFIGDIR LIBEXECDIR HOSTNAME HOSTNAME_S RET LOGGER_TEXT
-    export NHC_PID NHC_START_TS WATCHDOG_PID FAIL_CNT FORCE_SETSID NHC_FD_OUT NHC_FD_ERR
+    export NHC_PID NHC_START_TS NHC_WATCHDOG FAIL_CNT FORCE_SETSID NHC_FD_OUT NHC_FD_ERR
 
     # Users may override this in /etc/sysconfig/nhc.
     NAME=${0/#*\/}
@@ -447,7 +476,13 @@ function nhcmain_finalize_env() {
 
     # If timestamps are desired, initialize them here.
     if [[ $TS -ne 0 ]]; then
-        TS=$(date '+%s')
+        if (( BASHVER >= 42 )); then
+            # BASH 4.2 and higher don't require executing the `date` command.
+            # FIXME:  Remove this "if" once 4.2 becomes required.
+            printf -v TS '%{%s}T' -1
+        else
+            TS=$(date '+%s')
+        fi
         ELAPSED_SECONDS=$SECONDS
         SECONDS=$((ELAPSED_SECONDS+TS))
         NHC_START_TS=$((TS-ELAPSED_SECONDS))
@@ -547,45 +582,62 @@ function nhcmain_load_scripts() {
 }
 
 function nhcmain_watchdog_timer() {
-    local TIMEOUT="$1" NHC_PID="$2"
-    local SLEEP_PID MAIN_NHC_HUNG=0
+    local TASK_TIMEOUT="$1" TASK_PID="$2" TASK="$3"
+    local SLEEP_PID=0 MAIN_NHC_HUNG=0
+
+    # Sanity checks
+    if [[ "$TASK_TIMEOUT" -eq 0 ]]; then
+        # If there's no timeout, there's no need for a watchdog timer.
+        return 0
+    elif ! kill -0 "${TASK_PID#-}" 2>/dev/null; then
+        # If the watched process has already ended, our process should
+        # already be dead, but obviously it's still going.  Bail.
+        return 0
+    elif [[ -n "$TASK" && "$TASK" != "NHC"* ]]; then
+        TASK="NHC subprocess ($TASK)"
+    else
+        TASK="NHC"
+    fi
 
     # Start sleep process in background first so we can obtain its PID and set traps to handle signals.
-    sleep $TIMEOUT &
+    sleep $TASK_TIMEOUT &
     SLEEP_PID=$!
+    #trap 'set +x' RETURN    # As needed for debugging
     trap '' ALRM TERM
     trap "kill -9 $SLEEP_PID >&/dev/null ; exit 0" EXIT HUP INT QUIT ILL ABRT FPE KILL SEGV PIPE USR1 USR2 CONT STOP TSTP TTIN TTOU PWR
-    # Now we wait for the sleep to finish or for our process to be killed by the main NHC process.
-    wait
+    # Now we wait for the sleep to finish or for this watchdog process to be killed by the task process.
+    wait ${SLEEP_PID}
 
     # If we get here, the watchdog timer has expired, and we need to kill the NHC process (group).  Start gently.
-    log "NHC watchdog timer ${BASHPID:-$$} ($TIMEOUT secs) has expired.  Signaling NHC:  kill -s ALRM -- $NHC_PID"
-    kill -s ALRM -- $NHC_PID || return 0
-    sleep 1
+    log "$TASK watchdog timer ${BASHPID:-$$} ($TASK_TIMEOUT secs) has expired.  Signaling $TASK:  kill -s ALRM -- $TASK_PID"
+    kill -s ALRM -- $TASK_PID || return 0
+    sleep_wait 1 $TASK_PID
 
     # Send a stronger signal this time.  If there's nothing left to receive our signal, we're done.
-    log "NHC watchdog timer ${BASHPID:-$$} terminating NHC:  kill -s TERM -- $NHC_PID"
-    kill -s TERM -- $NHC_PID 2>/dev/null || return 0
-    sleep 3
+    log "$TASK watchdog timer ${BASHPID:-$$} terminating $TASK:  kill -s TERM -- $TASK_PID"
+    kill -s TERM -- $TASK_PID 2>/dev/null || return 0
+    sleep_wait 3 $TASK_PID
 
     # If we still had things to kill, check one last time and kill by force.
-    log "NHC watchdog timer ${BASHPID:-$$} terminating NHC with extreme prejudice:  kill -s KILL -- $NHC_PID"
-    if kill -0 ${NHC_PID#-} 2>/dev/null ; then
-        # Setting this to true means it's the main NHC that's still around, not merely a hung child process.  That
-        # means the main NHC process hasn't been able to terminate gracefully and write the appropriate message to
-        # stdout or the status file.  Thus the watchdog has to be the one to call die().  If it's just a hung child,
-        # we don't want to call die() again and overwrite the status message.
-        MAIN_NHC_HUNG=1
+    log "$TASK watchdog timer ${BASHPID:-$$} terminating $TASK_PID with extreme prejudice:  kill -s KILL -- $TASK_PID"
+    if [[ "$NHC_PID" == "$TASK_PID" ]]; then
+        if kill -0 ${TASK_PID#-} 2>/dev/null ; then
+            # Setting this to true means it's the main NHC that's still around, not merely a hung child process.  That
+            # means the main NHC process hasn't been able to terminate gracefully and write the appropriate message to
+            # stdout or the status file.  Thus the watchdog has to be the one to call die().  If it's just a hung child,
+            # we don't want to call die() again and overwrite the status message.
+            MAIN_NHC_HUNG=1
+        fi
     fi
-    kill -s KILL -- $NHC_PID 2>/dev/null
-    sleep 1
-    if kill -0 ${NHC_PID#-} 2>/dev/null ; then
+    kill -s KILL -- $TASK_PID 2>/dev/null
+    sleep_wait 1 $TASK_PID
+    if kill -0 ${TASK_PID#-} 2>/dev/null ; then
         # If the main NHC survived a "kill -9" it must be defunct.  Assume it called die() and exited cleanly.
-        log "NHC process ${NHC_PID#-} is defunct.  Considering it terminated."
+        log "$TASK process ${TASK_PID#-} is defunct.  Considering it terminated."
     elif [[ $MAIN_NHC_HUNG -eq 1 ]]; then
         # If the main NHC process survived SIGTERM but not SIGKILL, it likely didn't exit cleanly.  Call die().
-        WATCHDOG_PID=0
-        die 142 "Watchdog timer unable to terminate hung NHC process ${NHC_PID#-}."
+        NHC_WATCHDOG=0
+        die 142 "Watchdog timer unable to terminate hung $TASK process ${TASK_PID#-}."
     fi
     return 0
 }
@@ -595,12 +647,12 @@ function nhcmain_set_watchdog() {
     if [[ $TIMEOUT -gt 0 ]]; then
         # Start watchdog timer process in its own session.
         set -m
-        eval nhcmain_watchdog_timer $TIMEOUT $((NHC_SID==0?NHC_PID:NHC_SID)) &
-        WATCHDOG_PID=$!
-        export WATCHDOG_PID
+        nhcmain_watchdog_timer $TIMEOUT $((NHC_SID==0?NHC_PID:NHC_SID)) &
+        export NHC_WATCHDOG=$!
         set +m
-        dbg "In ${BASHPID:-$$}:  Watchdog PID is $WATCHDOG_PID, NHC PID is $NHC_PID"
+        dbg "In ${BASHPID:-$$}:  Watchdog PID is $NHC_WATCHDOG, NHC PID is $NHC_PID"
     else
+        export NHC_WATCHDOG=0
         dbg "In ${BASHPID:-$$}:  No watchdog, NHC PID is $NHC_PID"
     fi
 }
@@ -726,7 +778,8 @@ function nhcmain_finish() {
 }
 
 ### Script guts begin here.
-NHC_ARGS_LIST=( "$@" )
+declare -irx BASHVER="${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}"
+declare -a NHC_ARGS_LIST=( "$@" )
 if [[ -n "$NHC_LOAD_ONLY" ]]; then
     # We're only supposed to define functions, not actually run anything.
     return 0 || exit 0
@@ -740,7 +793,7 @@ trap 'die 143 "Terminated by signal SIGTERM." ; exit 143' 15
 trap 'die 142 "Script timed out${CHECK:+ while executing \"$CHECK\"}." ; exit 142' 14
 
 nhcmain_init_env
-nhcmain_parse_cmdline "$@" || exit 10
+nhcmain_parse_cmdline "${NHC_ARGS_LIST[@]}" || exit 10
 nhcmain_load_sysconfig
 nhcmain_finalize_env
 if [[ -n "$EVAL_LINE" ]]; then
@@ -763,10 +816,10 @@ if [[ "$NHC_RM" == "sge" ]]; then
     if nhcmain_run_checks ; then
         nhcmain_finish
     fi
-    if [[ "$*" == *NHC_RM=sge* ]]; then
-        exec $0 "$@"
+    if [[ "${NHC_ARGS_LIST[*]}" == *NHC_RM=sge* ]]; then
+        exec $0 "${NHC_ARGS_LIST[@]}"
     else
-        exec $0 "$@" NHC_RM=sge
+        exec $0 "${NHC_ARGS_LIST[@]}" NHC_RM=sge
     fi
 else
     nhcmain_load_scripts

--- a/scripts/common.nhc
+++ b/scripts/common.nhc
@@ -230,7 +230,9 @@ function bash_stack_trace() {
 ###########################################################
 
 # Define regexp match check conditionally based on bash version.
-if [[ "${BASH_VERSINFO[0]}" != "" && ${BASH_VERSINFO[0]} -ge 3 ]]; then
+# FIXME:  BASH 3.x and earlier are no longer supported for NHC, so this `if`
+#         statement can probably be removed.
+if (( BASHVER >= 30 )); then
     # Check to see if parameter ($1) matches regexp ($2)
     function mcheck_regexp() {
         if [[ "$1" =~ $2 ]]; then
@@ -711,7 +713,7 @@ function nhc_common_get_unix_time() {
 
 # Run a subcommand with a timeout
 function nhc_cmd_with_timeout() {
-    local -i NHC_TO=0 RC=0
+    local -i NHC_TO=0 RC=0 RETPID=0 SUBPID=0 WDTPID=0
 
     if [[ "$1" == +([0-9]) ]]; then
         export NHC_TO=$1
@@ -720,8 +722,17 @@ function nhc_cmd_with_timeout() {
         export NHC_TO=$TIMEOUT
     fi
     dbg "$FUNCNAME():  Executing \"$*\" with $NHC_TO-second timeout."
-    $SHELL -c '( for ((s=NHC_TO; s>0; s--)); do sleep 1 ; kill -0 $$ || exit 0 ; done ; kill -s SIGTERM $$ && kill -0 $$ || exit 0 ; sleep 1 ; kill -s SIGKILL $$ ) >&/dev/null & exec "$@"' $1 "$@"
+    "$@" &
+    SUBPID=$!
+    nhcmain_watchdog_timer "$NHC_TO" "$SUBPID" "$1" &
+    WDTPID=$!
+    dbg "$FUNCNAME():  Waiting on subprocess $SUBPID (\"$1\") and watchdog timer $WDTPID..."
+    wait -fn -p RETPID $SUBPID $WDTPID
     RC=$?
+    dbg "$FUNCNAME():  Process $RETPID exited with return code $RC."
+    if (( RETPID != WDTPID )); then
+        kill_watchdog $WDTPID
+    fi
     dbg "$FUNCNAME():  Command \"$*\" returned $RC."
     return $RC
 }

--- a/scripts/common.nhc
+++ b/scripts/common.nhc
@@ -726,11 +726,11 @@ function nhc_cmd_with_timeout() {
     SUBPID=$!
     nhcmain_watchdog_timer "$NHC_TO" "$SUBPID" "$1" &
     WDTPID=$!
-    dbg "$FUNCNAME():  Waiting on subprocess $SUBPID (\"$1\") and watchdog timer $WDTPID..."
-    wait -fn -p RETPID $SUBPID $WDTPID
+    dbg "$FUNCNAME():  Waiting on subprocess $SUBPID (\"$1\"); watchdog timer is $WDTPID...."
+    wait $SUBPID
     RC=$?
-    dbg "$FUNCNAME():  Process $RETPID exited with return code $RC."
-    if (( RETPID != WDTPID )); then
+    dbg "$FUNCNAME():  Process $SUBPID exited with return code $RC."
+    if kill -s 0 $WDTPID >&/dev/null ; then
         kill_watchdog $WDTPID
     fi
     dbg "$FUNCNAME():  Command \"$*\" returned $RC."

--- a/scripts/common.nhc
+++ b/scripts/common.nhc
@@ -711,15 +711,19 @@ function nhc_common_get_unix_time() {
 
 # Run a subcommand with a timeout
 function nhc_cmd_with_timeout() {
-    local RET
+    local -i NHC_TO=0 RC=0
 
-    export NHC_TO="$1"
-    shift
-    #exec 3>&2 2>/dev/null
+    if [[ "$1" == +([0-9]) ]]; then
+        export NHC_TO=$1
+        shift
+    else
+        export NHC_TO=$TIMEOUT
+    fi
+    dbg "$FUNCNAME():  Executing \"$*\" with $NHC_TO-second timeout."
     $SHELL -c '( for ((s=NHC_TO; s>0; s--)); do sleep 1 ; kill -0 $$ || exit 0 ; done ; kill -s SIGTERM $$ && kill -0 $$ || exit 0 ; sleep 1 ; kill -s SIGKILL $$ ) >&/dev/null & exec "$@"' $1 "$@"
-    RET=$?
-    #exec 2>&3 3>&-
-    return $RET
+    RC=$?
+    dbg "$FUNCNAME():  Command \"$*\" returned $RC."
+    return $RC
 }
 
 # Find system definition for UID range

--- a/scripts/lbnl_cmd.nhc
+++ b/scripts/lbnl_cmd.nhc
@@ -164,10 +164,11 @@ function check_cmd_status() {
         return 1
     fi
 
-    "$@" </dev/null >&/dev/null &
-    PID=$!
-    nhcmain_watchdog_timer "$CMD_TIMEOUT" "$PID" </dev/null >&/dev/null &
-    wait $PID
+    #"$@" </dev/null >&/dev/null &
+    #PID=$!
+    #nhcmain_watchdog_timer "$CMD_TIMEOUT" "$PID" </dev/null >&/dev/null &
+    #wait $PID
+    nhc_cmd_with_timeout "$CMD_TIMEOUT" "$@" </dev/null >&/dev/null
     RET=$?
 
     if [[ $RET -ne ${CMD_RETVAL:-0} ]]; then

--- a/test/nhc-test
+++ b/test/nhc-test
@@ -177,9 +177,10 @@ function test_nhc_driver() {
         is $? 0 'Simulated NHC process exists'
         kill -s 0 $WATCHDOG_PID >/dev/null 2>&1
         is $? 0 'Watchdog timer is running'
-        #sleep 2
+        sleep 2
         ## We set the watchdog timer for 1s, so it should be dead after 2s
-        wait -fn $NHC_PID $WATCHDOG_PID >&/dev/null
+        ###FIXME: Requires newer Bash### wait -fn $NHC_PID $WATCHDOG_PID >&/dev/null
+        wait $NHC_PID $WATCHDOG_PID
         kill -s 0 $NHC_PID >/dev/null 2>&1
         isnt $? 0 "Simulated NHC process $NHC_PID has been killed"
         kill -s 0 $WATCHDOG_PID >/dev/null 2>&1

--- a/test/nhc-test
+++ b/test/nhc-test
@@ -163,7 +163,7 @@ function test_nhc_driver() {
     TIMEOUT=0
     plan 1 "nhcmain_set_watchdog" && {
         nhcmain_set_watchdog
-        is $WATCHDOG_PID 0 'Watchdog should be disabled'
+        is $NHC_WATCHDOG 0 'Watchdog should be disabled'
     } ; unplan
 
     # Test watchdog timer.
@@ -172,14 +172,18 @@ function test_nhc_driver() {
     disown $NHC_PID
     nhcmain_watchdog_timer 1 $NHC_PID &
     WATCHDOG_PID=$!
-    plan 3 "nhcmain_watchdog_timer" && {
+    plan 4 "nhcmain_watchdog_timer" && {
         kill -s 0 $NHC_PID >/dev/null 2>&1
         is $? 0 'Simulated NHC process exists'
         kill -s 0 $WATCHDOG_PID >/dev/null 2>&1
         is $? 0 'Watchdog timer is running'
-        sleep 2
+        #sleep 2
+        ## We set the watchdog timer for 1s, so it should be dead after 2s
+        wait -fn $NHC_PID $WATCHDOG_PID >&/dev/null
         kill -s 0 $NHC_PID >/dev/null 2>&1
-        isnt $? 0 'Simulated NHC process has been killed'
+        isnt $? 0 "Simulated NHC process $NHC_PID has been killed"
+        kill -s 0 $WATCHDOG_PID >/dev/null 2>&1
+        isnt $? 0 "NHC watchdog timer process $WATCHDOG_PID has exited"
     } ; unplan
 
     # Empty config file should result in no checks.


### PR DESCRIPTION
From the log entries for the included commits (1dd668e57eaabd621153b08771c224ada6d806c0 and b171d831f492a08b06fa3fc52ce1dab578d5b4d2):

For some reason (probably simplicity), the `check_cmd_status()` check function was using a different method of spawning a subprocess with a timout than `check_cmd_status()` was.  The `nhc_cmd_with_timeout()` function was written specifically to facilitate consistency in coding that exact functionality, but only `check_cmd_output()` was using it.  The `check_cmd_status()` check function was launching the subcommand directly and trying to use `nhcmain_watchdog_timer()` to create its watchdog timer process.

As observed in https://github.com/mej/nhc/issues/104, `check_cmd_status()` (but *not* `check_cmd_output()`) was leaving behind watchdog timer and `sleep` processes that should have been terminated when the subcommand exited.  Unfortunately, `nhcmain_watchdog_timer()` was not written with this use case in mind, nor was `kill_watchdog()` expecting to have to clean up multiple child processes.

This will be addressed in 2 ways.  For the "fix-only" 1.4.4 tree, I've switched `check_cmd_status()` to using `nhc_cmd_with_timeout()` since it uses a different mechanism and has not displayed this behavior. The longer term fix will be to refactor the watchdog code in `nhc` itself and use that code whenever launching subcommands is needed.

This should address https://github.com/mej/nhc/issues/104 for the 1.4.4 branch but will be applied to both for now, once tested and verified.

----

As referenced in the above commits, the longer-term fix for the 1.5+ branch is a refactoring of all the watchdog timer code in `nhc` so that multiple distinct timers can be managed simultaneously, including their termination in case of successful subprocess/program exit.  Lack of proper cleanup was ultimately the key cause of https://github.com/mej/nhc/issues/104's leaked shell+`sleep` processes.

**NOTE**:  The `nhc` script itself does *not* keep track of all the PIDs for all the timers it has spawned off, only the main one (for the top-level `nhc` process).  Any other timer PIDs must be tracked by whatever spawned them.  In particular, `nhc_cmd_with_timeout()` tracks both the task and the timer PIDs and ensures that both processes have exited before it returns.