### PR TITLE
lbnl-nhc.spec.in:  Allow for normal user access

### DIFF
--- a/lbnl-nhc.spec.in
+++ b/lbnl-nhc.spec.in
@@ -39,6 +39,10 @@
 %{!?nhc_script_dir:%global nhc_script_dir %{_sysconfdir}/%{sname}/scripts}
 %{!?nhc_helper_dir:%global nhc_helper_dir %{_libexecdir}/%{sname}}
 
+### Build conditional(s)
+# Should NHC be accessible for normal users' use?
+%bcond_without useraccess
+
 
 Summary: LBNL Node Health Check
 Name: %{name}
@@ -79,7 +83,7 @@ project home page at https://github.com/mej/nhc
 
 
 %install
-umask 0077
+umask %{?with_useraccess:0022}%{!?with_useraccess:0077}
 %{__make} install DESTDIR=$RPM_BUILD_ROOT %{?mflags_install}
 
 


### PR DESCRIPTION
At LANL, we have use cases that will require `nhc` and its script files to be readable by normal system users.  Previously, several directories owned by the `lbnl-nhc` RPM package had permissions of `0700` for security/privacy reasons; however, nothing in the RPM itself is privacy- or security-sensitive, so there's no reason to limit functionality unnecessarily.

It's still possible to obtain the prior behavior by building without `useraccess` (i.e., `rpmbuild --without useraccess ...`), but the default is now to use the less restrictive permissions.

Closes #122.