### PR TITLE
Fix an error caused by system's /tmp being full when running checks in lbnl_hw.nhc

### DIFF
--- a/scripts/lbnl_hw.nhc
+++ b/scripts/lbnl_hw.nhc
@@ -85,7 +85,7 @@ function nhc_hw_cpu_gather_data() {
             MHZ="${FIELD[3]}"
             MHZ="${MHZ/%.*}"
         fi
-    done <<< "${CPUDATA}"
+    done < <( echo "${CPUDATA}" )
 
     if [[ $PROCESSOR -ge 0 && $HW_SOCKETS -eq 0 ]]; then
         HW_SOCKETS=$((PROCESSOR+1))
@@ -158,7 +158,7 @@ function nhc_hw_mem_gather_data() {
         elif [[ "${FIELD[0]}" = "SwapFree:" ]]; then
             HW_SWAP_FREE=${FIELD[1]}
         fi
-    done <<< "$MEMDATA"
+    done < <(echo "$MEMDATA" )
 
     dbg "Found $HW_RAM_TOTAL kB RAM ($HW_RAM_FREE kB free)"
     dbg "Found $HW_SWAP_TOTAL kB swap ($HW_SWAP_FREE kB free)"
@@ -236,7 +236,7 @@ function nhc_hw_kmod_gather_data() {
 
     while read -a FIELD ; do
         HW_MODULES+=( "${FIELD[0]}" )
-    done <<< "$MODDATA"
+    done < <( "$MODDATA" )
 
     export HW_MODULES
     dbg "Found kernel modules:  ${HW_MODULES[*]}"
@@ -280,7 +280,7 @@ function nhc_hw_eth_gather_data() {
             DEV=${FIELD[0]%%:*}
             HW_ETH_DEV+=( "${DEV}" )
         fi
-    done <<< "${DEVDATA}"
+    done < <( echo "${DEVDATA}" )
     export HW_ETH_DEV
     dbg "Found network devices:  ${HW_ETH_DEV[*]}"
 }

--- a/scripts/lbnl_hw.nhc
+++ b/scripts/lbnl_hw.nhc
@@ -85,7 +85,7 @@ function nhc_hw_cpu_gather_data() {
             MHZ="${FIELD[3]}"
             MHZ="${MHZ/%.*}"
         fi
-    done < <( echo "${CPUDATA}" )
+    done < <(echo "${CPUDATA}" )
 
     if [[ $PROCESSOR -ge 0 && $HW_SOCKETS -eq 0 ]]; then
         HW_SOCKETS=$((PROCESSOR+1))
@@ -236,7 +236,7 @@ function nhc_hw_kmod_gather_data() {
 
     while read -a FIELD ; do
         HW_MODULES+=( "${FIELD[0]}" )
-    done < <( "$MODDATA" )
+    done < <(echo "$MODDATA" )
 
     export HW_MODULES
     dbg "Found kernel modules:  ${HW_MODULES[*]}"
@@ -280,7 +280,7 @@ function nhc_hw_eth_gather_data() {
             DEV=${FIELD[0]%%:*}
             HW_ETH_DEV+=( "${DEV}" )
         fi
-    done < <( echo "${DEVDATA}" )
+    done < <(echo "${DEVDATA}" )
     export HW_ETH_DEV
     dbg "Found network devices:  ${HW_ETH_DEV[*]}"
 }


### PR DESCRIPTION
The error in question can be easily reproduced by having for example `check_hw_cpuinfo`, `check_hw_eth` or `check_hw_physmem` configured in the system's `nhc.conf` and filling up `/tmp`.
Currently what happens is:
```terminal
[root@c1104 ~]# df -h /tmp/
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           512M  512M     0 100% /tmp
[root@c1104 ~]# nhc -ad
DEBUG:  Debugging activated via -d option.
ERROR:  nhc:  Health check failed:  check_hw_cpuinfo:  Actual CPU socket count (1) does not match expected (2).
ERROR:  nhc:  Health check failed:  check_hw_physmem:  Actual RAM size (0 kB) less than minimum allowed (263504064 kB).
ERROR:  nhc:  Health check failed:  check_hw_eth:  Ethernet device ib0 not detected.
ERROR:  nhc:  3 health checks failed.
```
After the changes in the PR:
```terminal
[root@c1104 ~]# df -h /tmp/
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           512M  512M     0 100% /tmp
[root@c1104 ~]# nhc -ad
DEBUG:  Debugging activated via -d option.
[root@c1104 ~]# echo $?
0
```