### PR TITLE
New functions to check ALL filesystems of a given type

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,16 @@ _**Example** (make sure `/tmp` has at least 1000 inodes)_:  `check_fs_inodes /tm
 
 <br />
 
+##### check_all_fs_inodes
+`check_all_fs_inodes fstype [min] [max]`
+
+Ensures that ALL filesystems of type _fstype_ has at least _min_ but no more than _max_ total inodes.  Either may be blank. Calls check_fs_inodes for each filesystem.
+
+_**Example** (make sure xfs filesystems have at least 1000 inodes)_:  `check_all_fs_inodes xfs 1k`
+
+
+<br />
+
 
 ##### check_fs_ifree
 `check_fs_ifree mountpoint min`
@@ -768,6 +778,16 @@ _**Example** (make sure `/local` has at least 100 inodes free)_:  `check_fs_ifre
 
 <br />
 
+##### check_all_fs_ifree
+`check_all_fs_ifree fstype min`
+
+Ensures that ALL filesystems of type _fstype_ have at least _min_ free inodes. Calls check_fs_ifree for each filesystem.
+
+_**Example** (make sure xfs filesystems have at least 100 inodes free)_:  `check_all_fs_ifree xfs 100`
+
+
+<br />
+
 
 ##### check_fs_iused
 `check_fs_iused mountpoint max`
@@ -777,6 +797,16 @@ Ensures that the specified _mountpoint_ has no more than _max_ used inodes.
 > **WARNING:**  Use of this check requires execution of the `/usr/bin/df` command which may HANG in cases of NFS failure!  If you use this check, consider also using [Detached Mode](#detached-mode)!
 
 _**Example** (make sure `/tmp` has no more than 1 million used inodes)_:  `check_fs_iused /tmp 1M`
+
+
+<br />
+
+##### check_all_fs_iused
+`check_all_fs_iused fstype max`
+
+Ensures that ALL filesystems of type _fstype_ have no more than _max_ used inodes. Calls check_fs_iused for each filesystem.
+
+_**Example** (make sure xfs filesystems have no more than 1 million used inodes)_:  `check_all_fs_iused xfs 1M`
 
 
 <br />
@@ -859,6 +889,17 @@ _**Example**_:  `check_fs_size /tmp 512m 4g`
 > **WARNING:**  Use of this check requires execution of the `/usr/bin/df` command which may HANG in cases of NFS failure!  If you use this check, consider also using [Detached Mode](#detached-mode)!
 
 _**Example**_:  `check_fs_used / 98%`
+
+
+<br />
+
+
+##### check_all_fs_used
+`check_all_fs_used fstype maxused`
+
+Checks that ALL filesystems of type _fstype_ have less than _maxused_ space consumed.  Calls check_fs_used for each filesystem.
+
+_**Example**_:  `check_all_fs_used xfs 98%`
 
 
 <br />

--- a/scripts/lbnl_fs.nhc
+++ b/scripts/lbnl_fs.nhc
@@ -451,6 +451,28 @@ function check_fs_used() {
     return 0
 }
 
+
+# Check that ALL filesystems of type ($1) has at most a specified amount ($2) of
+# used space.  This may be either a percentage or a number of kB.
+# The function check_fs_used is called for each filesystem.
+function check_all_fs_used() {
+    local TYPE=$1
+    local MAX_USED=$2
+    local i
+
+    if [[ ${#DF_DEV[*]} -eq 0 ]]; then
+        nhc_fs_df_gather_data
+    fi
+
+    for ((i=0; i < ${#DF_DEV[*]}; i++)); do
+        if [[ "${DF_TYPE[$i]}" != "$TYPE" ]]; then
+            continue
+        fi
+        check_fs_used "${DF_MNTPT[$i]}" "$MAX_USED"
+    done
+    return 0
+}
+
 # Check to make sure a filesystem ($1) has between a minimum ($2) and
 # a maximum ($3) amount of inodes.  Either may be blank.  To check for
 # a specific inode count, pass the same value for both parameters.
@@ -488,6 +510,28 @@ function check_fs_inodes() {
             return 1
         fi
         return 0
+    done
+    return 0
+}
+
+# Check to make sure ALL filesystems of type ($1) has between a minimum ($2) and
+# a maximum ($3) amount of inodes.  Either may be blank.  To check for
+# a specific inode count, pass the same value for both parameters.
+function check_all_fs_inodes() {
+    local TYPE=$1
+    local MIN_INODES=$2
+    local MAX_INODES=$3
+    local i
+
+    if [[ ${#DFI_DEV[*]} -eq 0 ]]; then
+        nhc_fs_dfi_gather_data
+    fi
+
+    for ((i=0; i < ${#DFI_DEV[*]}; i++)); do
+        if [[ "${DFI_TYPE[$i]}" != "$TYPE" ]]; then
+            continue
+        fi
+        check_fs_inodes "${DF_MNTPT[$i]}" "$MIN_INODES" "$MAX_INODES"
     done
     return 0
 }
@@ -533,6 +577,26 @@ function check_fs_ifree() {
     return 0
 }
 
+# Check that ALL filesystems of type ($1) has at least a specified amount ($2) of
+# free inodes.  This may be either a percentage or an exact number.
+function check_all_fs_ifree() {
+    local TYPE=$1
+    local MIN_IFREE=$2
+    local i
+
+    if [[ ${#DFI_DEV[*]} -eq 0 ]]; then
+        nhc_fs_dfi_gather_data
+    fi
+
+    for ((i=0; i < ${#DFI_DEV[*]}; i++)); do
+        if [[ "${DFI_TYPE[$i]}" != "$TYPE" ]]; then
+            continue
+        fi
+        check_fs_ifree "${DF_MNTPT[$i]}" "$MIN_IFREE"
+    done
+    return 0
+}
+
 # Check that filesystem ($1) has at most a specified amount ($2) of
 # used inodes.  This may be either a percentage or an exact number.
 function check_fs_iused() {
@@ -569,6 +633,26 @@ function check_fs_iused() {
             fi
         fi
         return 0
+    done
+    return 0
+}
+
+# Check that ALL filesystems of type ($1) has at most a specified amount ($2) of
+# used inodes.  This may be either a percentage or an exact number.
+function check_all_fs_iused() {
+    local TYPE=$1
+    local MAX_IUSED=$2
+    local i
+
+    if [[ ${#DFI_DEV[*]} -eq 0 ]]; then
+        nhc_fs_dfi_gather_data
+    fi
+
+    for ((i=0; i < ${#DFI_DEV[*]}; i++)); do
+        if [[ "${DFI_TYPE[$i]}" != "$TYPE" ]]; then
+            continue
+        fi
+        check_fs_iused "${DFI_MNTPT[$i]}" "${MAX_IUSED}"
     done
     return 0
 }


### PR DESCRIPTION
We use NHC on many file servers to check the filesystem usage, and we have wound up with a total of 75 lines in nhc.conf similar to this one:

niflfs7.fysik.dtu.dk  || check_fs_used /u/camd 90%

All these many lines are difficult to maintain, and therefore it is desirable to have catch-all checks that apply to ALL filesystems of a given type, for example, XFS filesystems.

This PR proposes four new functions that supplement check_fs_* functions: check_all_fs_inodes, check_all_fs_ifree, check_all_fs_iused, check_all_fs_used. The nwe functions simply loop over all filesystems and calls the original check_fs_* functions on each filesystem of the given type.

An example usage is:

* || check_all_fs_used xfs 90%