### PR TITLE
The NHC_RM must be exported to the ONLINE_NODE/OFFLINE_NODE scripts

### DIFF
--- a/nhc
+++ b/nhc
@@ -859,6 +859,8 @@ function nhcmain_finalize_env() {
     if [[ -z "$NHC_RM" ]]; then
         nhcmain_find_rm || NHC_RM='none'
     fi
+    # The NHC_RM must be exported to the ONLINE_NODE/OFFLINE_NODE scripts
+    export NHC_RM
     if [[ "$NHC_RM" == 'none' || "$NHC_RM" == 'sge' ]]; then
         # None of these makes sense without a resource manager!
         # And with SGE, we return the status and note directly from NHC.


### PR DESCRIPTION
With NHC 1.5 we get an error in nhc.log when on/offlining a Slurm node:

20250827 13:21:51 [] /usr/libexec/nhc/node-mark-online x007
/usr/libexec/nhc/node-mark-online:  Unsupported RM detected in /usr/libexec/nhc/node-mark-online:  ""

In fact nhc correctly autodetects NHC_RM=slurm but never exports that variable to the ONLINE_NODE/OFFLINE_NODE scripts.

A workaround is to export NHC_RM in nhc.conf as suggested by many people:

* || export NHC_RM=slurm

However, the correct fix appears to be exporting NHC_RM in nhc as proposed in this PR.