### PR TITLE
Resuming node from state maint is an invalid node state transition

### DIFF
--- a/helpers/node-mark-online
+++ b/helpers/node-mark-online
@@ -65,7 +65,12 @@ elif [[ "$NHC_RM" == "slurm" ]]; then
             echo "$0:  State \"$STATUS\" not yet handled; ignoring."
             exit 0
             ;;
-        down*|drain*|drng*|fail*|maint*)
+        maint*)
+            # Resuming nodes in this state is an "Invalid node state transition"
+            echo "$0:  Resuming from state \"$STATUS\" is an invalid node state transition; ignoring."
+            exit 0
+            ;;
+        down*|drain*|drng*|fail*)
             # If there is no old note, and we've not been told to ignore that, do not online the node.
             if [[ "$OLD_NOTE_LEADER" == "none" && "$IGNORE_EMPTY_NOTE" != "1" ]]; then
                 echo "$0:  Not onlining $HOSTNAME:  No note set."


### PR DESCRIPTION
```
$ scontrol create reservation=PreventMaint nodes=ALL Flags=MAINT users=root starttime=now duration=1-0
Reservation created: PreventMaint

$ scontrol update nodename=nid001000 state=resume
slurm_update error: Invalid node state transition
```

Then in the slurmctld logs:
```
[2026-04-04T17:30.651] Invalid node state transition request for node nid001000 from=MAINT to=RESUME
_slurm_rpc_update_node for nid001000: Invalid node state transition
```

As you may imagine this makes the logs extremely hard to read when a whole cluster is in State=MAINT.
