### PR TITLE
read /proc/cpuinfo once instead of slowly line by line

### DIFF
--- a/scripts/lbnl_hw.nhc
+++ b/scripts/lbnl_hw.nhc
@@ -25,12 +25,14 @@ MCELOG_MAX_UNCORRECTED_RATE="${MCELOG_MAX_UNCORRECTED_RATE:-0}"
 # Read hardware information from /proc and /sys files.
 function nhc_hw_gather_data() {
     local IFS LINE CORES SIBLINGS MHZ PROCESSOR PHYS_ID PORT INDEX DEV
-    local -a FIELD PHYS_IDS IB_PORTS
+    local -a FIELD PHYS_IDS IB_PORTS CPUINFO
 
     # Gather CPU info
     PROCESSOR=-1
     if [[ -e /proc/cpuinfo ]]; then
-        while read -a FIELD ; do
+        mapfile -t CPUINFO < /proc/cpuinfo
+        for LINE in "${CPUINFO[@]}"; do
+            read -r -a FIELD <<< "${LINE}"
             if [[ "${FIELD[0]} ${FIELD[1]}" = "processor :" ]]; then
                 : $((PROCESSOR++))
             elif [[ "${FIELD[0]} ${FIELD[1]} ${FIELD[2]}" = "physical id :" ]]; then
@@ -47,7 +49,7 @@ function nhc_hw_gather_data() {
                 MHZ="${FIELD[3]}"
                 MHZ="${MHZ/%.*}"
             fi
-        done < /proc/cpuinfo
+        done
     fi
     if [[ $PROCESSOR -ge 0 && $HW_SOCKETS -eq 0 ]]; then
         HW_SOCKETS=$((PROCESSOR+1))


### PR DESCRIPTION
Using nhc on the new high core-count AMD CPUs (2x 192 cores) in our cluster, reading /proc/cpuinfo line by line takes too long. The complexity of this one loop is quadratic:
/proc/cpuinfo has 10752 lines -> 10.5s
/proc/cpuinfo has 21504 lines -> 40.6s
Hence, nhc can easily run into timeouts, although it has barely started to run tests.
When reading the file first completely, the function always finishes in a fraction of a second (0.308s)